### PR TITLE
upgrading logback to latest 1.1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <at.sign>@</at.sign>
     <bdb-version>5.0.104</bdb-version>
     <derby-version>10.11.1.1</derby-version>
-    <logback-version>1.1.3</logback-version>
+    <logback-version>1.1.7</logback-version>
     <guava-version>18.0</guava-version>
     <fasterxml-jackson-version>2.5.3</fasterxml-jackson-version>
     <slf4j-version>1.7.12</slf4j-version>


### PR DESCRIPTION
frameworks like Spring use latest LogBack version (1.1.7) and it becomes difficult to use Qpid with it, as we need to downgrade logback manually to avoid conflicts. 
Therefore, proposing to upgrade LogBack verison to 1.1.7 in Qpid java.
