### PR TITLE
Fixe bug:  the 'contextPath' does not end with '/'

### DIFF
--- a/broker-plugins/management-http/src/main/java/resources/index.html
+++ b/broker-plugins/management-http/src/main/java/resources/index.html
@@ -44,7 +44,7 @@
             var firstSlashPos = documentURL.indexOf("/", documentURL.indexOf("//") + 2);
             if (managementPageStart > firstSlashPos)
             {
-                contextPath = documentURL.substring(firstSlashPos, managementPageStart);
+                contextPath = documentURL.substring(firstSlashPos, managementPageStart + 1);
             }
             return contextPath;
         }


### PR DESCRIPTION
when '(managementPageStart > firstSlashPos)' is true that the 'contextPath' does not end with '/'. And this will cause 404 error.

Signed-off-by: Jin Dong <dong.jin10@zte.com.cn>